### PR TITLE
feat: implement Never Engine core logic with CLI commands, MCP server…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ The library lives in `library/`. Each markdown file follows a specific format th
 ---
 name: Rule Category Name
 description: What this category covers
+category: security  # One of: security, style, logic, workflow, quality, core
 tags: [relevant, tags]
 globs: "**/*.ts"
 alwaysApply: false
@@ -23,13 +24,27 @@ alwaysApply: false
 - Never do the other thing that causes different problems
 ```
 
+### Frontmatter Fields
+
 The frontmatter tells the sync engines how to handle the rules:
 
-- `name`: Human readable category name
-- `description`: Brief explanation for the list command
-- `tags`: Used for filtering and grouping
-- `globs`: File patterns where these rules apply (Cursor uses this)
-- `alwaysApply`: Whether rules load regardless of file type
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Human-readable category name |
+| `description` | string | Yes | Brief explanation for the list command |
+| `category` | enum | No | One of: `security`, `style`, `logic`, `workflow`, `quality`, `core` |
+| `tags` | string[] | No | Used for filtering and grouping |
+| `globs` | string | No | File patterns where these rules apply (default: `**/*`) |
+| `alwaysApply` | boolean | No | Whether rules load regardless of file type (default: `true`) |
+
+### Category Guidelines
+
+- **security**: Rules preventing vulnerabilities, credential exposure, injection attacks
+- **style**: Code formatting, naming conventions, documentation requirements
+- **logic**: Algorithm correctness, edge case handling, state management
+- **workflow**: Development process, git practices, deployment constraints
+- **quality**: Code structure, maintainability, testing requirements
+- **core**: Fundamental rules that apply across all projects
 
 Each rule should start with "Never" and describe a specific, actionable constraint. Avoid vague guidance like "write clean code" in favor of concrete requirements like "never use magic numbers without defining named constants."
 
@@ -51,6 +66,23 @@ The sync engines in `cli/src/engines/` convert parsed rules to tool-specific for
 3. Add a config option in the `targets` section
 4. Update the sync command to call your engine
 
+### Using the SyncEngine Class
+
+For complex integrations, you can use the `SyncEngine` class in `cli/src/engines/SyncEngine.ts`:
+
+```typescript
+import { SyncEngine } from './engines/SyncEngine.js';
+
+const engine = new SyncEngine({
+    projectPath: '/path/to/project',
+    dryRun: false,
+    verbose: true,
+});
+
+const summary = engine.syncAll();
+console.log(`Generated ${summary.results.length} files`);
+```
+
 ## Pull Request Process
 
 1. Create a branch from `main` with a descriptive name
@@ -69,6 +101,15 @@ The project uses TypeScript with strict mode enabled. Follow the existing patter
 
 No linting rules are enforced automatically yet, but that might change.
 
+## MCP Server Contributions
+
+The MCP server in `/mcp` exposes Never constraints to AI agents via the Model Context Protocol. Contributions here should:
+
+1. Follow the MCP SDK patterns in `mcp/src/index.ts`
+2. Add new tools with proper input schemas
+3. Document usage in `mcp/README.md`
+
 ## Questions
 
 Open an issue if something is unclear. Better to ask than to guess.
+

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -13,7 +13,10 @@
         "commander": "^12.1.0",
         "glob": "^10.4.5",
         "gray-matter": "^4.0.3",
-        "yaml": "^2.4.5"
+        "minimatch": "^9.0.5",
+        "simple-git": "^3.27.0",
+        "yaml": "^2.4.5",
+        "zod": "^3.24.1"
       },
       "bin": {
         "never": "dist/index.js"
@@ -476,6 +479,30 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
@@ -524,6 +551,30 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -650,6 +701,21 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1248,14 +1314,12 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/cac": {
@@ -1381,7 +1445,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1595,6 +1658,17 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1610,6 +1684,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -1892,30 +1979,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -2261,16 +2324,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {
@@ -2306,7 +2371,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2704,6 +2768,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.30.0.tgz",
+      "integrity": "sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/source-map-js": {
@@ -3301,6 +3380,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,7 +31,10 @@
     "gray-matter": "^4.0.3",
     "yaml": "^2.4.5",
     "chalk": "^5.3.0",
-    "glob": "^10.4.5"
+    "glob": "^10.4.5",
+    "minimatch": "^9.0.5",
+    "simple-git": "^3.27.0",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^18.16.0",

--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -1,0 +1,249 @@
+/**
+ * `never lint` command
+ * Check current git diff against active "Nevers" and report violations
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import chalk from 'chalk';
+import { simpleGit } from 'simple-git';
+import { minimatch } from 'minimatch';
+import { loadConfig, getLibraryPath } from '../utils/config.js';
+import { loadAllRuleSets, getRulesForSets } from '../engines/parser.js';
+import type { LintViolation } from '../schema.js';
+import type { ParsedRule } from '../engines/parser.js';
+
+interface LintOptions {
+    staged?: boolean;
+    json?: boolean;
+    verbose?: boolean;
+    config?: string;
+}
+
+interface DiffFile {
+    file: string;
+    additions: string[];
+    lineNumbers: number[];
+}
+
+/**
+ * Parse git diff output to extract changed files and lines
+ */
+function parseDiff(diffOutput: string): DiffFile[] {
+    const files: DiffFile[] = [];
+    const fileBlocks = diffOutput.split('diff --git');
+
+    for (const block of fileBlocks) {
+        if (!block.trim()) continue;
+
+        // Extract filename
+        const fileMatch = block.match(/a\/(.+?) b\//);
+        if (!fileMatch) continue;
+
+        const file = fileMatch[1];
+        const additions: string[] = [];
+        const lineNumbers: number[] = [];
+
+        // Parse hunks for additions
+        const lines = block.split('\n');
+        let currentLine = 0;
+
+        for (const line of lines) {
+            // Track line numbers from hunk headers
+            const hunkMatch = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+            if (hunkMatch) {
+                currentLine = parseInt(hunkMatch[1], 10) - 1;
+                continue;
+            }
+
+            if (line.startsWith('+') && !line.startsWith('+++')) {
+                currentLine++;
+                additions.push(line.substring(1));
+                lineNumbers.push(currentLine);
+            } else if (!line.startsWith('-')) {
+                currentLine++;
+            }
+        }
+
+        if (additions.length > 0) {
+            files.push({ file, additions, lineNumbers });
+        }
+    }
+
+    return files;
+}
+
+/**
+ * Check if a rule applies to a given file path
+ */
+function ruleAppliesToFile(rule: ParsedRule, filePath: string): boolean {
+    const globs = rule.frontmatter.globs;
+    if (rule.frontmatter.alwaysApply) return true;
+    if (!globs || globs === '**/*') return true;
+
+    // Handle comma-separated globs
+    const patterns = globs.split(',').map(g => g.trim());
+    return patterns.some(pattern => minimatch(filePath, pattern));
+}
+
+/**
+ * Check for violations in the diff
+ */
+function checkViolations(
+    diffFiles: DiffFile[],
+    rules: ParsedRule[]
+): LintViolation[] {
+    const violations: LintViolation[] = [];
+
+    for (const diffFile of diffFiles) {
+        // Find applicable rules for this file
+        const applicableRules = rules.filter(rule => ruleAppliesToFile(rule, diffFile.file));
+
+        for (const rule of applicableRules) {
+            for (const neverRule of rule.rules) {
+                // Extract the core constraint from the rule text
+                const lowerRule = neverRule.toLowerCase();
+
+                // Check each addition for potential violations
+                for (let i = 0; i < diffFile.additions.length; i++) {
+                    const line = diffFile.additions[i].toLowerCase();
+                    const lineNum = diffFile.lineNumbers[i];
+
+                    // Common violation patterns
+                    const violationPatterns: Array<{ pattern: RegExp; trigger: string }> = [
+                        { pattern: /\bany\b/, trigger: 'use `any`' },
+                        { pattern: /\beval\s*\(/, trigger: 'use eval' },
+                        { pattern: /console\.(log|debug|info)\s*\(/, trigger: 'debugging statements' },
+                        { pattern: /\/\/\s*todo/i, trigger: 'todo comments' },
+                        { pattern: /\bvar\s+\w/, trigger: 'use `var`' },
+                        { pattern: /\.then\s*\(/, trigger: 'then() chains' },
+                        { pattern: /hardcoded|password\s*=\s*['"]/, trigger: 'hardcode' },
+                        { pattern: /@ts-ignore/, trigger: 'ts-ignore' },
+                        { pattern: /eslint-disable/, trigger: 'eslint-disable' },
+                    ];
+
+                    for (const { pattern, trigger } of violationPatterns) {
+                        if (lowerRule.includes(trigger) && pattern.test(line)) {
+                            violations.push({
+                                file: diffFile.file,
+                                line: lineNum,
+                                rule: neverRule,
+                                ruleId: rule.id,
+                                severity: 'warning',
+                                message: `Possible violation of: ${neverRule}`,
+                            });
+                            break; // One violation per rule per line
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return violations;
+}
+
+/**
+ * Main lint command handler
+ */
+export async function lintCommand(options: LintOptions): Promise<void> {
+    const projectPath = process.cwd();
+    const configPath = options.config || join(projectPath, '.never', 'config.yaml');
+    const verbose = options.verbose || false;
+
+    console.log(chalk.bold('Running Never lint...\\n'));
+
+    // Initialize git
+    const git = simpleGit(projectPath);
+
+    // Check if this is a git repository
+    const isGitRepo = await git.checkIsRepo();
+    if (!isGitRepo) {
+        console.error(chalk.red('Not a git repository. Lint requires git.'));
+        process.exit(1);
+    }
+
+    // Get the diff
+    let diffOutput: string;
+    try {
+        if (options.staged) {
+            diffOutput = await git.diff(['--cached']);
+        } else {
+            diffOutput = await git.diff();
+        }
+    } catch (error) {
+        console.error(chalk.red('Failed to get git diff:'), error);
+        process.exit(1);
+    }
+
+    if (!diffOutput) {
+        console.log(chalk.green('No changes to lint.'));
+        return;
+    }
+
+    // Parse the diff
+    const diffFiles = parseDiff(diffOutput);
+    if (verbose) {
+        console.log(`Found changes in ${diffFiles.length} file(s)\\n`);
+    }
+
+    // Load rules
+    let ruleSets: string[] = ['core'];
+    if (existsSync(configPath)) {
+        const config = loadConfig(configPath);
+        if (config) {
+            ruleSets = config.rules;
+        }
+    }
+
+    const libraryPath = getLibraryPath();
+    if (!existsSync(libraryPath)) {
+        console.error(chalk.red('Rule library not found.'));
+        process.exit(1);
+    }
+
+    const allRuleSets = loadAllRuleSets(libraryPath);
+    const activeRules = getRulesForSets(allRuleSets, ruleSets);
+
+    if (verbose) {
+        console.log(`Using ${activeRules.length} rule files from sets: ${ruleSets.join(', ')}\\n`);
+    }
+
+    // Check for violations
+    const violations = checkViolations(diffFiles, activeRules);
+
+    // Output results
+    if (options.json) {
+        console.log(JSON.stringify(violations, null, 2));
+        return;
+    }
+
+    if (violations.length === 0) {
+        console.log(chalk.green('✓ No violations found!'));
+        return;
+    }
+
+    console.log(chalk.yellow(`Found ${violations.length} potential violation(s):\\n`));
+
+    // Group by file
+    const byFile = new Map<string, LintViolation[]>();
+    for (const v of violations) {
+        if (!byFile.has(v.file)) {
+            byFile.set(v.file, []);
+        }
+        byFile.get(v.file)!.push(v);
+    }
+
+    for (const [file, fileViolations] of byFile) {
+        console.log(chalk.cyan(`  ${file}`));
+        for (const v of fileViolations) {
+            const lineInfo = v.line ? `:${v.line}` : '';
+            console.log(chalk.yellow(`    ⚠ ${file}${lineInfo}`));
+            console.log(chalk.gray(`      ${v.rule}`));
+        }
+        console.log();
+    }
+
+    // Exit with error code if violations found (useful for CI)
+    process.exit(1);
+}

--- a/cli/src/commands/scan.ts
+++ b/cli/src/commands/scan.ts
@@ -1,0 +1,376 @@
+/**
+ * `never scan` command
+ * Auto-detect the tech stack and recommend rule packs
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import chalk from 'chalk';
+import type { ScanResult } from '../schema.js';
+
+interface ScanOptions {
+    json?: boolean;
+    verbose?: boolean;
+}
+
+interface PackageJson {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    scripts?: Record<string, string>;
+}
+
+interface PyProjectToml {
+    project?: {
+        dependencies?: string[];
+    };
+    tool?: {
+        poetry?: {
+            dependencies?: Record<string, string>;
+        };
+    };
+}
+
+/**
+ * Detect programming languages in the project
+ */
+function detectLanguages(projectPath: string): string[] {
+    const languages: string[] = [];
+
+    // TypeScript
+    if (existsSync(join(projectPath, 'tsconfig.json'))) {
+        languages.push('typescript');
+    }
+
+    // JavaScript (if package.json exists but no tsconfig)
+    if (existsSync(join(projectPath, 'package.json')) && !languages.includes('typescript')) {
+        languages.push('javascript');
+    }
+
+    // Python
+    if (
+        existsSync(join(projectPath, 'pyproject.toml')) ||
+        existsSync(join(projectPath, 'requirements.txt')) ||
+        existsSync(join(projectPath, 'setup.py')) ||
+        existsSync(join(projectPath, 'Pipfile'))
+    ) {
+        languages.push('python');
+    }
+
+    // Rust
+    if (existsSync(join(projectPath, 'Cargo.toml'))) {
+        languages.push('rust');
+    }
+
+    // Go
+    if (existsSync(join(projectPath, 'go.mod'))) {
+        languages.push('go');
+    }
+
+    // Java
+    if (existsSync(join(projectPath, 'pom.xml')) || existsSync(join(projectPath, 'build.gradle'))) {
+        languages.push('java');
+    }
+
+    // Ruby
+    if (existsSync(join(projectPath, 'Gemfile'))) {
+        languages.push('ruby');
+    }
+
+    // PHP
+    if (existsSync(join(projectPath, 'composer.json'))) {
+        languages.push('php');
+    }
+
+    return languages;
+}
+
+/**
+ * Detect frameworks from package.json dependencies
+ */
+function detectNodeFrameworks(projectPath: string): string[] {
+    const frameworks: string[] = [];
+    const packageJsonPath = join(projectPath, 'package.json');
+
+    if (!existsSync(packageJsonPath)) {
+        return frameworks;
+    }
+
+    try {
+        const packageJson: PackageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+        const allDeps = {
+            ...packageJson.dependencies,
+            ...packageJson.devDependencies,
+        };
+
+        // React ecosystem
+        if (allDeps['react']) {
+            frameworks.push('react');
+        }
+        if (allDeps['next']) {
+            frameworks.push('nextjs');
+        }
+
+        // Vue ecosystem
+        if (allDeps['vue']) {
+            frameworks.push('vue');
+        }
+        if (allDeps['nuxt']) {
+            frameworks.push('nuxt');
+        }
+
+        // Angular
+        if (allDeps['@angular/core']) {
+            frameworks.push('angular');
+        }
+
+        // Svelte
+        if (allDeps['svelte']) {
+            frameworks.push('svelte');
+        }
+
+        // Node.js backends
+        if (allDeps['express']) {
+            frameworks.push('express');
+        }
+        if (allDeps['fastify']) {
+            frameworks.push('fastify');
+        }
+        if (allDeps['nestjs'] || allDeps['@nestjs/core']) {
+            frameworks.push('nestjs');
+        }
+
+        // Testing
+        if (allDeps['jest']) {
+            frameworks.push('jest');
+        }
+        if (allDeps['vitest']) {
+            frameworks.push('vitest');
+        }
+        if (allDeps['mocha']) {
+            frameworks.push('mocha');
+        }
+
+        // Bundlers
+        if (allDeps['webpack']) {
+            frameworks.push('webpack');
+        }
+        if (allDeps['vite']) {
+            frameworks.push('vite');
+        }
+        if (allDeps['esbuild']) {
+            frameworks.push('esbuild');
+        }
+
+        // CSS frameworks
+        if (allDeps['tailwindcss']) {
+            frameworks.push('tailwind');
+        }
+
+    } catch {
+        // Ignore parse errors
+    }
+
+    return frameworks;
+}
+
+/**
+ * Detect Python frameworks
+ */
+function detectPythonFrameworks(projectPath: string): string[] {
+    const frameworks: string[] = [];
+
+    // Check requirements.txt
+    const requirementsPath = join(projectPath, 'requirements.txt');
+    if (existsSync(requirementsPath)) {
+        try {
+            const content = readFileSync(requirementsPath, 'utf-8').toLowerCase();
+            if (content.includes('django')) frameworks.push('django');
+            if (content.includes('flask')) frameworks.push('flask');
+            if (content.includes('fastapi')) frameworks.push('fastapi');
+            if (content.includes('pytest')) frameworks.push('pytest');
+            if (content.includes('numpy')) frameworks.push('numpy');
+            if (content.includes('pandas')) frameworks.push('pandas');
+            if (content.includes('tensorflow') || content.includes('torch')) {
+                frameworks.push('ml');
+            }
+        } catch {
+            // Ignore read errors
+        }
+    }
+
+    // Check pyproject.toml (simplified parsing)
+    const pyprojectPath = join(projectPath, 'pyproject.toml');
+    if (existsSync(pyprojectPath)) {
+        try {
+            const content = readFileSync(pyprojectPath, 'utf-8').toLowerCase();
+            if (content.includes('django')) frameworks.push('django');
+            if (content.includes('flask')) frameworks.push('flask');
+            if (content.includes('fastapi')) frameworks.push('fastapi');
+        } catch {
+            // Ignore read errors
+        }
+    }
+
+    return [...new Set(frameworks)]; // Remove duplicates
+}
+
+/**
+ * Detect development tools
+ */
+function detectTools(projectPath: string): string[] {
+    const tools: string[] = [];
+
+    // AI tools
+    if (existsSync(join(projectPath, '.cursor'))) {
+        tools.push('cursor');
+    }
+    if (existsSync(join(projectPath, 'CLAUDE.md'))) {
+        tools.push('claude');
+    }
+    if (existsSync(join(projectPath, '.github', 'copilot'))) {
+        tools.push('copilot');
+    }
+
+    // Version control
+    if (existsSync(join(projectPath, '.git'))) {
+        tools.push('git');
+    }
+
+    // Docker
+    if (existsSync(join(projectPath, 'Dockerfile')) || existsSync(join(projectPath, 'docker-compose.yml'))) {
+        tools.push('docker');
+    }
+
+    // CI/CD
+    if (existsSync(join(projectPath, '.github', 'workflows'))) {
+        tools.push('github-actions');
+    }
+    if (existsSync(join(projectPath, '.gitlab-ci.yml'))) {
+        tools.push('gitlab-ci');
+    }
+
+    // Linters/Formatters
+    if (existsSync(join(projectPath, '.eslintrc.js')) || existsSync(join(projectPath, '.eslintrc.json')) || existsSync(join(projectPath, 'eslint.config.js'))) {
+        tools.push('eslint');
+    }
+    if (existsSync(join(projectPath, '.prettierrc')) || existsSync(join(projectPath, 'prettier.config.js'))) {
+        tools.push('prettier');
+    }
+
+    return tools;
+}
+
+/**
+ * Map detected items to recommended rule packs
+ */
+function getRecommendedPacks(languages: string[], frameworks: string[]): string[] {
+    const packs: string[] = ['core']; // Always include core
+
+    // Language packs
+    if (languages.includes('typescript') || languages.includes('javascript')) {
+        packs.push('typescript');
+    }
+    if (languages.includes('python')) {
+        packs.push('python');
+    }
+    if (languages.includes('rust')) {
+        packs.push('rust');
+    }
+    if (languages.includes('go')) {
+        packs.push('go');
+    }
+
+    // Framework packs
+    if (frameworks.includes('react') || frameworks.includes('nextjs')) {
+        packs.push('react');
+    }
+    if (frameworks.includes('vue') || frameworks.includes('nuxt')) {
+        packs.push('vue');
+    }
+    if (frameworks.includes('angular')) {
+        packs.push('angular');
+    }
+    if (frameworks.includes('django') || frameworks.includes('flask') || frameworks.includes('fastapi')) {
+        packs.push('python-web');
+    }
+
+    return [...new Set(packs)];
+}
+
+/**
+ * Perform a complete project scan
+ */
+export function scanProject(projectPath: string): ScanResult {
+    const languages = detectLanguages(projectPath);
+    const nodeFrameworks = detectNodeFrameworks(projectPath);
+    const pythonFrameworks = detectPythonFrameworks(projectPath);
+    const frameworks = [...nodeFrameworks, ...pythonFrameworks];
+    const tools = detectTools(projectPath);
+    const recommendedPacks = getRecommendedPacks(languages, frameworks);
+
+    return {
+        frameworks,
+        languages,
+        tools,
+        recommendedPacks,
+    };
+}
+
+/**
+ * Main scan command handler
+ */
+export async function scanCommand(options: ScanOptions): Promise<void> {
+    const projectPath = process.cwd();
+    const verbose = options.verbose || false;
+
+    console.log(chalk.bold('Scanning project...\\n'));
+
+    const result = scanProject(projectPath);
+
+    if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+    }
+
+    // Display results
+    console.log(chalk.blue('📋 Detected Languages:'));
+    if (result.languages.length > 0) {
+        for (const lang of result.languages) {
+            console.log(`   ${chalk.green('•')} ${lang}`);
+        }
+    } else {
+        console.log(chalk.gray('   No languages detected'));
+    }
+
+    console.log();
+    console.log(chalk.blue('🔧 Detected Frameworks:'));
+    if (result.frameworks.length > 0) {
+        for (const framework of result.frameworks) {
+            console.log(`   ${chalk.green('•')} ${framework}`);
+        }
+    } else {
+        console.log(chalk.gray('   No frameworks detected'));
+    }
+
+    console.log();
+    console.log(chalk.blue('🛠️  Detected Tools:'));
+    if (result.tools.length > 0) {
+        for (const tool of result.tools) {
+            console.log(`   ${chalk.green('•')} ${tool}`);
+        }
+    } else {
+        console.log(chalk.gray('   No tools detected'));
+    }
+
+    console.log();
+    console.log(chalk.bold.yellow('📦 Recommended Rule Packs:'));
+    for (const pack of result.recommendedPacks) {
+        console.log(`   ${chalk.cyan('→')} ${pack}`);
+    }
+
+    if (verbose) {
+        console.log();
+        console.log(chalk.dim('Run `never init` to create a config with these packs'));
+        console.log(chalk.dim('Run `never sync` to generate constraint files'));
+    }
+}

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -115,17 +115,17 @@ export async function syncCommand(options: SyncOptions): Promise<void> {
     // CLAUDE.md
     if (config.targets.claude) {
         console.log('Generating CLAUDE.md...');
-        const claudePath = updateClaudeFile(projectPath, activeRules, dryRun);
-        generatedFiles.push(claudePath);
-        console.log(`  Updated: ${claudePath}`);
+        const claudeResult = updateClaudeFile(projectPath, activeRules, dryRun);
+        generatedFiles.push(claudeResult.path);
+        console.log(`  Updated: ${claudeResult.path}`);
     }
 
     // AGENTS.md
     if (config.targets.agents) {
         console.log('Generating AGENTS.md...');
-        const agentsPath = updateAgentsFile(projectPath, activeRules, dryRun);
-        generatedFiles.push(agentsPath);
-        console.log(`  Updated: ${agentsPath}`);
+        const agentsResult = updateAgentsFile(projectPath, activeRules, dryRun);
+        generatedFiles.push(agentsResult.path);
+        console.log(`  Updated: ${agentsResult.path}`);
     }
 
     console.log(`\nSync complete. Generated ${generatedFiles.length} files.`);

--- a/cli/src/engines/SyncEngine.ts
+++ b/cli/src/engines/SyncEngine.ts
@@ -1,0 +1,227 @@
+/**
+ * SyncEngine - Central orchestration for all sync operations
+ * Coordinates rule processing and output generation for multiple targets
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { loadConfig, getLibraryPath, type NeverConfig } from '../utils/config.js';
+import { detectProject, suggestRuleSets } from '../utils/detect.js';
+import { loadAllRuleSets, getRulesForSets, type ParsedRule } from '../engines/parser.js';
+import { rulesToMdc, writeMdcFiles } from '../engines/to-mdc.js';
+import { updateClaudeFile } from '../engines/to-claude.js';
+import { updateAgentsFile } from '../engines/to-agents.js';
+import type { SyncResult } from '../schema.js';
+
+export interface SyncEngineOptions {
+    projectPath: string;
+    configPath?: string;
+    dryRun?: boolean;
+    verbose?: boolean;
+}
+
+export interface SyncSummary {
+    results: SyncResult[];
+    totalRuleFiles: number;
+    totalRules: number;
+    targets: string[];
+}
+
+/**
+ * SyncEngine class for orchestrating rule synchronization
+ */
+export class SyncEngine {
+    private projectPath: string;
+    private config: NeverConfig;
+    private activeRules: ParsedRule[];
+    private dryRun: boolean;
+    private verbose: boolean;
+    private results: SyncResult[];
+
+    constructor(options: SyncEngineOptions) {
+        this.projectPath = options.projectPath;
+        this.dryRun = options.dryRun || false;
+        this.verbose = options.verbose || false;
+        this.results = [];
+        this.activeRules = [];
+
+        // Load configuration
+        this.config = this.loadConfiguration(options.configPath);
+    }
+
+    /**
+     * Load and merge configuration
+     */
+    private loadConfiguration(configPath?: string): NeverConfig {
+        const path = configPath || join(this.projectPath, '.never', 'config.yaml');
+
+        if (existsSync(path)) {
+            const loaded = loadConfig(path);
+            if (loaded) {
+                return loaded;
+            }
+        }
+
+        // Fall back to auto-detection
+        const projectInfo = detectProject(this.projectPath);
+        const suggestedRules = suggestRuleSets(projectInfo);
+
+        return {
+            version: 1,
+            rules: suggestedRules,
+            targets: {
+                cursor: projectInfo.hasCursor || existsSync(join(this.projectPath, '.cursor')),
+                claude: true,
+                agents: true,
+            },
+            autoDetect: true,
+        };
+    }
+
+    /**
+     * Load rules from the library
+     */
+    loadRules(): void {
+        // Apply auto-detection if enabled
+        if (this.config.autoDetect) {
+            const projectInfo = detectProject(this.projectPath);
+            const detectedRules = suggestRuleSets(projectInfo);
+            this.config.rules = [...new Set([...this.config.rules, ...detectedRules])];
+
+            if (this.verbose) {
+                console.log(`Auto-detected frameworks: ${projectInfo.frameworks.join(', ') || 'none'}`);
+            }
+        }
+
+        // Load rule library
+        const libraryPath = getLibraryPath();
+        if (!existsSync(libraryPath)) {
+            throw new Error(`Rule library not found at: ${libraryPath}`);
+        }
+
+        const allRuleSets = loadAllRuleSets(libraryPath);
+        this.activeRules = getRulesForSets(allRuleSets, this.config.rules);
+
+        if (this.verbose) {
+            console.log(`Loaded ${this.activeRules.length} rule files from sets: ${this.config.rules.join(', ')}`);
+        }
+    }
+
+    /**
+     * Sync rules to Cursor .mdc files
+     */
+    syncToCursor(): SyncResult[] {
+        if (!this.config.targets.cursor) {
+            return [];
+        }
+
+        const mdcOutputs = rulesToMdc(this.activeRules);
+        const files = writeMdcFiles(this.projectPath, mdcOutputs, this.dryRun);
+
+        const results: SyncResult[] = files.map((path, index) => ({
+            path,
+            content: mdcOutputs[index]?.content || '',
+            written: !this.dryRun,
+            target: 'cursor' as const,
+        }));
+
+        this.results.push(...results);
+        return results;
+    }
+
+    /**
+     * Sync rules to CLAUDE.md
+     */
+    syncToClaude(): SyncResult {
+        const engineResult = updateClaudeFile(this.projectPath, this.activeRules, this.dryRun);
+
+        const result: SyncResult = {
+            path: engineResult.path,
+            content: engineResult.content,
+            written: engineResult.written,
+            target: 'claude' as const,
+        };
+
+        this.results.push(result);
+        return result;
+    }
+
+    /**
+     * Sync rules to AGENTS.md
+     */
+    syncToAgents(): SyncResult {
+        const engineResult = updateAgentsFile(this.projectPath, this.activeRules, this.dryRun);
+
+        const result: SyncResult = {
+            path: engineResult.path,
+            content: engineResult.content,
+            written: engineResult.written,
+            target: 'agents' as const,
+        };
+
+        this.results.push(result);
+        return result;
+    }
+
+    /**
+     * Sync rules to SKILL.md (for AI agent skills)
+     */
+    syncToSkill(): SyncResult | null {
+        // SKILL.md is similar to AGENTS.md but for skill-based systems
+        // Only sync if explicitly enabled (future feature)
+        return null;
+    }
+
+    /**
+     * Run all enabled sync operations
+     */
+    syncAll(): SyncSummary {
+        this.loadRules();
+        const targets: string[] = [];
+
+        if (this.config.targets.cursor) {
+            this.syncToCursor();
+            targets.push('cursor');
+        }
+
+        if (this.config.targets.claude) {
+            this.syncToClaude();
+            targets.push('claude');
+        }
+
+        if (this.config.targets.agents) {
+            this.syncToAgents();
+            targets.push('agents');
+        }
+
+        const totalRules = this.activeRules.reduce((sum, rule) => sum + rule.rules.length, 0);
+
+        return {
+            results: this.results,
+            totalRuleFiles: this.activeRules.length,
+            totalRules,
+            targets,
+        };
+    }
+
+    /**
+     * Get active rules (after loadRules has been called)
+     */
+    getActiveRules(): ParsedRule[] {
+        return this.activeRules;
+    }
+
+    /**
+     * Get current configuration
+     */
+    getConfig(): NeverConfig {
+        return this.config;
+    }
+
+    /**
+     * Get all sync results
+     */
+    getResults(): SyncResult[] {
+        return this.results;
+    }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,13 +9,15 @@ import { Command } from 'commander';
 import { initCommand } from './commands/init.js';
 import { syncCommand } from './commands/sync.js';
 import { listCommand } from './commands/list.js';
+import { scanCommand } from './commands/scan.js';
+import { lintCommand } from './commands/lint.js';
 
 const program = new Command();
 
 program
     .name('never')
     .description('Universal AI Constraint Engine - Sync "Never" rules to AI coding agents')
-    .version('1.0.0');
+    .version('1.1.0');
 
 program
     .command('init')
@@ -37,5 +39,22 @@ program
     .option('-a, --all', 'Show all rules including disabled ones')
     .action(listCommand);
 
+program
+    .command('scan')
+    .description('Auto-detect tech stack and recommend rule packs')
+    .option('--json', 'Output in JSON format')
+    .option('-v, --verbose', 'Show detailed output')
+    .action(scanCommand);
+
+program
+    .command('lint')
+    .description('Check current git diff against active "Nevers" and report violations')
+    .option('--staged', 'Only check staged changes (for pre-commit hooks)')
+    .option('--json', 'Output violations in JSON format')
+    .option('-v, --verbose', 'Show detailed output')
+    .option('-c, --config <path>', 'Path to config file', '.never/config.yaml')
+    .action(lintCommand);
+
 // Use parseAsync to properly await async command handlers
 await program.parseAsync();
+

--- a/cli/src/schema.ts
+++ b/cli/src/schema.ts
@@ -1,0 +1,132 @@
+/**
+ * Rule Schema Definitions
+ * Zod-based schemas for Never rule validation and type safety
+ */
+
+import { z } from 'zod';
+
+/**
+ * Rule categories for classification
+ */
+export const RuleCategorySchema = z.enum([
+    'security',
+    'style',
+    'logic',
+    'workflow',
+    'quality',
+    'core',
+]);
+
+/**
+ * Severity levels for rules
+ */
+export const RuleSeveritySchema = z.enum(['error', 'warning', 'info']);
+
+/**
+ * Individual rule within a rule file
+ */
+export const RuleItemSchema = z.object({
+    id: z.string().describe('Unique identifier for the rule'),
+    category: RuleCategorySchema.describe('Category this rule belongs to'),
+    tags: z.array(z.string()).describe('Tags for filtering and grouping'),
+    content: z.string().describe('The markdown "Never" constraint text'),
+    triggers: z.array(z.string()).describe('Glob patterns that trigger this rule'),
+    severity: RuleSeveritySchema.optional().default('warning'),
+});
+
+/**
+ * Frontmatter schema for rule markdown files
+ */
+export const RuleFrontmatterSchema = z.object({
+    name: z.string().describe('Human-readable rule category name'),
+    description: z.string().describe('Brief explanation of what this category covers'),
+    category: RuleCategorySchema.optional().describe('Primary category for the rule set'),
+    tags: z.array(z.string()).default([]).describe('Tags for filtering'),
+    globs: z.string().default('**/*').describe('File patterns where these rules apply'),
+    alwaysApply: z.boolean().default(true).describe('Whether rules load regardless of file type'),
+});
+
+/**
+ * Complete parsed rule file structure
+ */
+export const ParsedRuleSchema = z.object({
+    id: z.string().describe('Unique identifier e.g., "core/safety"'),
+    filename: z.string().describe('Source filename e.g., "safety.md"'),
+    frontmatter: RuleFrontmatterSchema,
+    content: z.string().describe('Markdown content without frontmatter'),
+    rules: z.array(z.string()).describe('Individual "Never" rules extracted'),
+    category: RuleCategorySchema.optional(),
+});
+
+/**
+ * Rule set containing multiple parsed rules
+ */
+export const RuleSetSchema = z.object({
+    name: z.string().describe('e.g., "core", "typescript", "react"'),
+    rules: z.array(ParsedRuleSchema),
+});
+
+/**
+ * Sync result for tracking generated files
+ */
+export const SyncResultSchema = z.object({
+    path: z.string().describe('Path to the generated/updated file'),
+    content: z.string().describe('Content that was written'),
+    written: z.boolean().describe('Whether the file was actually written (false for dry-run)'),
+    target: z.enum(['cursor', 'claude', 'agents', 'skill']).describe('Target platform'),
+});
+
+/**
+ * Lint violation reported by the lint command
+ */
+export const LintViolationSchema = z.object({
+    file: z.string().describe('File where violation was found'),
+    line: z.number().optional().describe('Line number if applicable'),
+    rule: z.string().describe('The rule that was violated'),
+    ruleId: z.string().describe('Unique rule identifier'),
+    severity: RuleSeveritySchema,
+    message: z.string().describe('Description of the violation'),
+});
+
+/**
+ * Scan result for tech stack detection
+ */
+export const ScanResultSchema = z.object({
+    frameworks: z.array(z.string()).describe('Detected frameworks'),
+    languages: z.array(z.string()).describe('Detected programming languages'),
+    tools: z.array(z.string()).describe('Detected development tools'),
+    recommendedPacks: z.array(z.string()).describe('Recommended rule packs'),
+});
+
+// Type exports
+export type RuleCategory = z.infer<typeof RuleCategorySchema>;
+export type RuleSeverity = z.infer<typeof RuleSeveritySchema>;
+export type RuleItem = z.infer<typeof RuleItemSchema>;
+export type RuleFrontmatter = z.infer<typeof RuleFrontmatterSchema>;
+export type ParsedRule = z.infer<typeof ParsedRuleSchema>;
+export type RuleSet = z.infer<typeof RuleSetSchema>;
+export type SyncResult = z.infer<typeof SyncResultSchema>;
+export type LintViolation = z.infer<typeof LintViolationSchema>;
+export type ScanResult = z.infer<typeof ScanResultSchema>;
+
+/**
+ * Validate rule frontmatter from parsed YAML
+ */
+export function validateFrontmatter(data: unknown): RuleFrontmatter {
+    return RuleFrontmatterSchema.parse(data);
+}
+
+/**
+ * Validate a complete parsed rule
+ */
+export function validateParsedRule(data: unknown): ParsedRule {
+    return ParsedRuleSchema.parse(data);
+}
+
+/**
+ * Safe validation that returns null instead of throwing
+ */
+export function safeParseFrontmatter(data: unknown): RuleFrontmatter | null {
+    const result = RuleFrontmatterSchema.safeParse(data);
+    return result.success ? result.data : null;
+}

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -106,6 +106,9 @@ export function getLibraryPath(): string {
         }
     }
 
-    // Default to relative path
-    return './library';
+    // No valid library path found - throw error to let caller handle
+    throw new Error(
+        'Never library not found. Ensure it exists in one of the expected locations:\n' +
+        possiblePaths.map(p => `  - ${p}`).join('\n')
+    );
 }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,56 @@
+# Never MCP Server
+
+Model Context Protocol (MCP) server for the Never constraint engine. This server exposes a `get_relevant_constraints` tool that AI agents can call to get only the "Never" rules applicable to the files they are currently editing.
+
+## Installation
+
+```bash
+cd mcp
+npm install
+npm run build
+```
+
+## Usage with Claude Desktop
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "never": {
+      "command": "node",
+      "args": ["/path/to/never/mcp/dist/index.js"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Available Tools
+
+### get_relevant_constraints
+
+Returns Never constraints applicable to the files being edited.
+
+**Parameters:**
+- `files` (required): Array of file paths being edited
+- `projectPath` (optional): Root path of the project
+
+**Example:**
+```json
+{
+  "files": ["src/components/Button.tsx", "src/utils/api.ts"],
+  "projectPath": "/path/to/project"
+}
+```
+
+**Returns:** Markdown-formatted list of applicable constraints, filtered by file patterns.
+
+## How It Works
+
+1. When called, the server loads all rules from the Never library
+2. It matches each file against rule glob patterns
+3. Only rules that apply to at least one file are included
+4. Results are formatted as markdown for easy reading
+
+This ensures the AI only sees relevant constraints, reducing context window usage and keeping focus on applicable rules.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1320 @@
+{
+    "name": "@never/mcp-server",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@never/mcp-server",
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "@modelcontextprotocol/sdk": "^1.0.0",
+                "gray-matter": "^4.0.3",
+                "minimatch": "^9.0.5",
+                "yaml": "^2.4.5"
+            },
+            "bin": {
+                "never-mcp": "dist/index.js"
+            },
+            "devDependencies": {
+                "@types/node": "^18.16.0",
+                "typescript": "^5.5.3"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.9",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+            "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk": {
+            "version": "1.25.2",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
+            "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
+            "license": "MIT",
+            "dependencies": {
+                "@hono/node-server": "^1.19.7",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
+                "content-type": "^1.0.5",
+                "cors": "^2.8.5",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "express": "^5.0.1",
+                "express-rate-limit": "^7.5.0",
+                "jose": "^6.1.1",
+                "json-schema-typed": "^8.0.2",
+                "pkce-challenge": "^5.0.0",
+                "raw-body": "^3.0.0",
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "license": "MIT"
+        },
+        "node_modules/body-parser": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.7.0",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/cors": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4",
+                "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/eventsource": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+            "license": "MIT",
+            "dependencies": {
+                "eventsource-parser": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+            "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
+        "node_modules/extend-shallow": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extendable": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gray-matter": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+            "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-yaml": "^3.13.1",
+                "kind-of": "^6.0.2",
+                "section-matter": "^1.0.0",
+                "strip-bom-string": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hono": {
+            "version": "4.11.4",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+            "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
+        "node_modules/jose": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+            "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/js-yaml": {
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/pkce-challenge": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.14.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
+        },
+        "node_modules/section-matter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+            "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+            "license": "MIT",
+            "dependencies": {
+                "extend-shallow": "^2.0.1",
+                "kind-of": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/strip-bom-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+            "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+            "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.1",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+            "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.25 || ^4"
+            }
+        }
+    }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@never/mcp-server",
+    "version": "1.0.0",
+    "description": "MCP Server for Never constraint engine - provides get_relevant_constraints tool",
+    "type": "module",
+    "main": "dist/index.js",
+    "bin": {
+        "never-mcp": "./dist/index.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "dev": "tsc -w",
+        "start": "node dist/index.js"
+    },
+    "keywords": [
+        "mcp",
+        "never",
+        "ai-constraints",
+        "claude"
+    ],
+    "author": "",
+    "license": "MIT",
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "minimatch": "^9.0.5",
+        "gray-matter": "^4.0.3",
+        "yaml": "^2.4.5"
+    },
+    "devDependencies": {
+        "@types/node": "^18.16.0",
+        "typescript": "^5.5.3"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    }
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Never MCP Server
+ * Model Context Protocol server that exposes get_relevant_constraints tool
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+    CallToolRequestSchema,
+    ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { getRelevantConstraints } from './tools/get_relevant_constraints.js';
+
+// Create the MCP server
+const server = new Server(
+    {
+        name: 'never-mcp',
+        version: '1.0.0',
+    },
+    {
+        capabilities: {
+            tools: {},
+        },
+    }
+);
+
+// Register available tools
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+        tools: [
+            {
+                name: 'get_relevant_constraints',
+                description:
+                    'Get Never constraints applicable to the files currently being edited. ' +
+                    'Returns only the rules that match the file patterns, keeping the AI focused on relevant constraints.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        files: {
+                            type: 'array',
+                            items: { type: 'string' },
+                            description: 'List of file paths being edited',
+                        },
+                        projectPath: {
+                            type: 'string',
+                            description: 'Root path of the project (optional, defaults to cwd)',
+                        },
+                    },
+                    required: ['files'],
+                },
+            },
+        ],
+    };
+});
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    if (name === 'get_relevant_constraints') {
+        const files = (args?.files as string[]) || [];
+        const projectPath = (args?.projectPath as string) || process.cwd();
+
+        try {
+            const result = await getRelevantConstraints(files, projectPath);
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: result,
+                    },
+                ],
+            };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: `Error getting constraints: ${message}`,
+                    },
+                ],
+                isError: true,
+            };
+        }
+    }
+
+    return {
+        content: [
+            {
+                type: 'text',
+                text: `Unknown tool: ${name}`,
+            },
+        ],
+        isError: true,
+    };
+});
+
+// Start the server
+async function main() {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('Never MCP Server running on stdio');
+}
+
+main().catch(console.error);

--- a/mcp/src/tools/get_relevant_constraints.ts
+++ b/mcp/src/tools/get_relevant_constraints.ts
@@ -1,0 +1,213 @@
+/**
+ * get_relevant_constraints tool implementation
+ * Returns Never constraints applicable to the files being edited
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { minimatch } from 'minimatch';
+import matter from 'gray-matter';
+
+// ESM-compatible __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface RuleFrontmatter {
+    name: string;
+    description: string;
+    tags: string[];
+    globs: string;
+    alwaysApply: boolean;
+}
+
+interface ParsedRule {
+    id: string;
+    filename: string;
+    frontmatter: RuleFrontmatter;
+    content: string;
+    rules: string[];
+}
+
+const DEFAULT_FRONTMATTER: RuleFrontmatter = {
+    name: 'Unnamed Rule',
+    description: 'No description provided',
+    tags: [],
+    globs: '**/*',
+    alwaysApply: true,
+};
+
+/**
+ * Find the library path relative to where the server is running
+ */
+function findLibraryPath(projectPath: string): string | null {
+    const possiblePaths = [
+        join(projectPath, 'library'),
+        join(projectPath, 'node_modules', 'never-cli', 'library'),
+        join(dirname(dirname(__dirname)), 'library'), // Relative to mcp/dist
+    ];
+
+    for (const p of possiblePaths) {
+        if (existsSync(p)) {
+            return p;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Parse a rule file and extract rules
+ */
+function parseRuleFile(filePath: string, ruleSetName: string): ParsedRule | null {
+    if (!existsSync(filePath)) {
+        return null;
+    }
+
+    try {
+        const content = readFileSync(filePath, 'utf-8');
+        const { data, content: markdownContent } = matter(content);
+
+        const frontmatter: RuleFrontmatter = {
+            ...DEFAULT_FRONTMATTER,
+            ...data,
+        };
+
+        // Extract "Never" rules
+        const rules: string[] = [];
+        const lines = markdownContent.split('\n');
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (trimmed.match(/^[-*]\s+Never\s+/i)) {
+                rules.push(trimmed.replace(/^[-*]\s+/, '').trim());
+            }
+        }
+
+        const filename = basename(filePath);
+        const id = `${ruleSetName}/${filename.replace('.md', '')}`;
+
+        return {
+            id,
+            filename,
+            frontmatter,
+            content: markdownContent,
+            rules,
+        };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Load all rules from the library
+ */
+function loadAllRules(libraryPath: string): ParsedRule[] {
+    const rules: ParsedRule[] = [];
+
+    function walkDirectory(dirPath: string): void {
+        const entries = readdirSync(dirPath);
+        const dirName = basename(dirPath);
+
+        for (const entry of entries) {
+            const fullPath = join(dirPath, entry);
+            const stat = statSync(fullPath);
+
+            if (stat.isFile() && entry.endsWith('.md')) {
+                const parsed = parseRuleFile(fullPath, dirName);
+                if (parsed) {
+                    rules.push(parsed);
+                }
+            } else if (stat.isDirectory()) {
+                walkDirectory(fullPath);
+            }
+        }
+    }
+
+    walkDirectory(libraryPath);
+    return rules;
+}
+
+/**
+ * Check if a rule applies to a given file path
+ */
+function ruleAppliesToFile(rule: ParsedRule, filePath: string): boolean {
+    if (rule.frontmatter.alwaysApply) {
+        return true;
+    }
+
+    const globs = rule.frontmatter.globs;
+    if (!globs || globs === '**/*') {
+        return true;
+    }
+
+    const patterns = globs.split(',').map(g => g.trim());
+    return patterns.some(pattern => minimatch(filePath, pattern));
+}
+
+/**
+ * Format rules as markdown for the AI
+ */
+function formatRulesAsMarkdown(rules: ParsedRule[]): string {
+    if (rules.length === 0) {
+        return 'No specific constraints apply to the current files.';
+    }
+
+    const sections: string[] = [];
+    sections.push('# Applicable Never Constraints\n');
+    sections.push('The following constraints apply to the files you are editing:\n');
+
+    // Group by rule name
+    const grouped = new Map<string, ParsedRule[]>();
+    for (const rule of rules) {
+        const name = rule.frontmatter.name;
+        if (!grouped.has(name)) {
+            grouped.set(name, []);
+        }
+        grouped.get(name)!.push(rule);
+    }
+
+    for (const [name, groupRules] of grouped) {
+        sections.push(`## ${name}\n`);
+        for (const rule of groupRules) {
+            for (const neverRule of rule.rules) {
+                sections.push(`- ${neverRule}`);
+            }
+        }
+        sections.push('');
+    }
+
+    return sections.join('\n');
+}
+
+/**
+ * Main tool implementation
+ */
+export async function getRelevantConstraints(
+    files: string[],
+    projectPath: string
+): Promise<string> {
+    const libraryPath = findLibraryPath(projectPath);
+
+    if (!libraryPath) {
+        return 'Never library not found in the project.';
+    }
+
+    const allRules = loadAllRules(libraryPath);
+
+    if (allRules.length === 0) {
+        return 'No rules found in the Never library.';
+    }
+
+    // Filter rules based on file patterns
+    const relevantRules = new Set<ParsedRule>();
+
+    for (const file of files) {
+        for (const rule of allRules) {
+            if (ruleAppliesToFile(rule, file)) {
+                relevantRules.add(rule);
+            }
+        }
+    }
+
+    return formatRulesAsMarkdown([...relevantRules]);
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "declaration": true
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}


### PR DESCRIPTION
## Schema & Library Expansion
- Created Zod-based RuleSchema with id, category, tags, content, triggers
- Added schema.ts with validation functions and type exports

## CLI Feature Implementation
- Added 'never scan' command for auto-detecting tech stack
- Added 'never lint' command to check git diff against rules
- Created SyncEngine class for orchestrating sync operations
- Updated index.ts with new command registrations (v1.1.0)

## CodeRabbit Review Fixes
- Fixed marker finding in to-claude.ts and to-agents.ts to search end marker after start marker
- Added EngineSyncResult interface for dry-run testability
- Updated updateClaudeFile and updateAgentsFile to return structured results
- Improved getLibraryPath() to throw error instead of invalid fallback
- Added new dependencies: zod, minimatch, simple-git

## MCP Server Integration
- Created /mcp directory with full scaffolding
- Implemented get_relevant_constraints tool with ESM compatibility
- Added file-matching logic for context-aware rule selection

## Documentation Updates
- Updated CONTRIBUTING.md with new schema documentation
- Added category guidelines and MCP server contribution section

All 31 tests passing.

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `scan` command to auto-detect project tech stack and recommend relevant rule packs.
  * Added `lint` command to analyze git diffs and detect rule violations.
  * Introduced MCP Server integration for Claude Desktop to access project constraints.
  * Rule system now supports category field for better organization.

* **Documentation**
  * Enhanced CONTRIBUTING.md with frontmatter field specifications and category guidelines.
  * Added MCP Server README with setup and usage instructions.

* **Chores**
  * CLI version updated to 1.1.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->